### PR TITLE
feat(playgrounds): display inputs controls from base components

### DIFF
--- a/libs/builder/helpers/angular/get-component-inputs.ts
+++ b/libs/builder/helpers/angular/get-component-inputs.ts
@@ -1,0 +1,55 @@
+import {ClassDeclaration, PropertyDeclaration} from 'ts-morph';
+
+import {forAllClasses} from '../typescript/class/for-all-classes';
+
+/**
+ * Retrieve all existing `@Input` of an Angular component, up through ascendant classes
+ *
+ * @param cls - ClassDeclaration
+ * @param condition - (cls: ClassDeclaration) => boolean
+ */
+export function getComponentInputs(
+	cls: ClassDeclaration,
+	condition: (cls: ClassDeclaration) => boolean = classHasNoParent,
+): PropertyDeclaration[] {
+	const allComponentAndParentsInputs: PropertyDeclaration[][] = [];
+
+	forAllClasses(cls, (c: ClassDeclaration) => {
+		const isBaseClass = c !== cls && condition(c);
+		allComponentAndParentsInputs.push(getComponentInputsProperties(c.getProperties()));
+		return isBaseClass;
+	});
+
+	return withoutOverriddenInputs(allComponentAndParentsInputs)
+}
+
+/**
+ * Keep only Angular `@Input` properties
+ *
+ * @param properties - PropertyDeclaration[]
+ */
+function getComponentInputsProperties(properties: PropertyDeclaration[]) {
+	return properties.filter((property: PropertyDeclaration) => !!property.getDecorator('Input'));
+}
+
+/**
+ * Removes parent class' properties if they have been overridden by a descendant class
+ *
+ * @param properties - PropertyDeclaration[][]
+ */
+function withoutOverriddenInputs(properties: PropertyDeclaration[][]) {
+	return properties.flat(1).reduce((acc, curr) => {
+		const propertyAlreadyExists = acc.find((p) => p.getName() === curr.getName());
+		if (propertyAlreadyExists) {
+			return acc;
+		}
+		return [...acc, curr];
+	}, [] as PropertyDeclaration[]);
+}
+
+/**
+ * @param cls - ClassDeclaration
+ */
+function classHasNoParent (cls: ClassDeclaration) {
+	return cls.getBaseClass() === undefined || cls.isAbstract()
+}

--- a/libs/builder/helpers/angular/get-component-inputs.ts
+++ b/libs/builder/helpers/angular/get-component-inputs.ts
@@ -8,48 +8,16 @@ import {forAllClasses} from '../typescript/class/for-all-classes';
  * @param cls - ClassDeclaration
  * @param condition - (cls: ClassDeclaration) => boolean
  */
-export function getComponentInputs(
-	cls: ClassDeclaration,
-	condition: (cls: ClassDeclaration) => boolean = classHasNoParent,
-): PropertyDeclaration[] {
-	const allComponentAndParentsInputs: PropertyDeclaration[][] = [];
+export function getComponentInputs(cls: ClassDeclaration): PropertyDeclaration[] {
+	const properties: Map<string, PropertyDeclaration> = new Map();
 
 	forAllClasses(cls, (c: ClassDeclaration) => {
-		const isBaseClass = c !== cls && condition(c);
-		allComponentAndParentsInputs.push(getComponentInputsProperties(c.getProperties()));
-		return isBaseClass;
+		c.getProperties().forEach((p: PropertyDeclaration) => {
+			if (!properties.has(p.getName()) && p.getDecorator('Input')) {
+				properties.set(p.getName(), p);
+			}
+		});
 	});
 
-	return withoutOverriddenInputs(allComponentAndParentsInputs)
-}
-
-/**
- * Keep only Angular `@Input` properties
- *
- * @param properties - PropertyDeclaration[]
- */
-function getComponentInputsProperties(properties: PropertyDeclaration[]) {
-	return properties.filter((property: PropertyDeclaration) => !!property.getDecorator('Input'));
-}
-
-/**
- * Removes parent class' properties if they have been overridden by a descendant class
- *
- * @param properties - PropertyDeclaration[][]
- */
-function withoutOverriddenInputs(properties: PropertyDeclaration[][]) {
-	return properties.flat(1).reduce((acc, curr) => {
-		const propertyAlreadyExists = acc.find((p) => p.getName() === curr.getName());
-		if (propertyAlreadyExists) {
-			return acc;
-		}
-		return [...acc, curr];
-	}, [] as PropertyDeclaration[]);
-}
-
-/**
- * @param cls - ClassDeclaration
- */
-function classHasNoParent (cls: ClassDeclaration) {
-	return cls.getBaseClass() === undefined || cls.isAbstract()
+	return Array.from(properties.values());
 }

--- a/libs/builder/helpers/angular/index.ts
+++ b/libs/builder/helpers/angular/index.ts
@@ -1,4 +1,5 @@
 export * from './get-component-decorator';
+export * from './get-component-inputs'
 export * from './get-directive-decorator';
 export * from './get-input-name';
 export * from './get-pipe-decorator';

--- a/libs/builder/helpers/playground/get-playground-inputs.ts
+++ b/libs/builder/helpers/playground/get-playground-inputs.ts
@@ -18,12 +18,14 @@ import {displayType} from '../typescript';
  * @param declaration
  */
 export function getPlaygroundComponentInputs(declaration: ClassDeclaration): NgDocPlaygroundProperties {
-	return declaration
-		.getProperties()
+	const componentParentClass = declaration.getBaseClass();
+	const componentParentClassProperties = componentParentClass?.getProperties() ?? [];
+	const componentProperties = declaration.getProperties();
+
+	return [...componentParentClassProperties, ...componentProperties]
 		.filter((property: PropertyDeclaration) => !!property.getDecorator('Input'))
 		.reduce((properties: NgDocPlaygroundProperties, property: PropertyDeclaration) => {
 			const inputName: string = getInputName(property);
-
 			return {...properties, ...propOrParamToPlaygroundProperty(property, inputName)};
 		}, {});
 }

--- a/libs/builder/helpers/playground/get-playground-inputs.ts
+++ b/libs/builder/helpers/playground/get-playground-inputs.ts
@@ -9,7 +9,7 @@ import {
 	TypeFormatFlags,
 } from 'ts-morph';
 
-import {getInputName} from '../angular';
+import {getComponentInputs, getInputName} from '../angular';
 import {extractDocs, extractParameterDocs} from '../extract-docs';
 import {displayType} from '../typescript';
 
@@ -18,16 +18,13 @@ import {displayType} from '../typescript';
  * @param declaration
  */
 export function getPlaygroundComponentInputs(declaration: ClassDeclaration): NgDocPlaygroundProperties {
-	const componentParentClass = declaration.getBaseClass();
-	const componentParentClassProperties = componentParentClass?.getProperties() ?? [];
-	const componentProperties = declaration.getProperties();
-
-	return [...componentParentClassProperties, ...componentProperties]
-		.filter((property: PropertyDeclaration) => !!property.getDecorator('Input'))
-		.reduce((properties: NgDocPlaygroundProperties, property: PropertyDeclaration) => {
+	return getComponentInputs(declaration).reduce(
+		(properties: NgDocPlaygroundProperties, property: PropertyDeclaration) => {
 			const inputName: string = getInputName(property);
 			return {...properties, ...propOrParamToPlaygroundProperty(property, inputName)};
-		}, {});
+		},
+		{},
+	);
 }
 
 /**

--- a/libs/builder/helpers/testing/get-component-inputs.spec.ts
+++ b/libs/builder/helpers/testing/get-component-inputs.spec.ts
@@ -1,0 +1,278 @@
+import {ClassDeclaration, Project, PropertyDeclaration, SourceFile} from 'ts-morph';
+
+import {getComponentInputs} from '../angular/get-component-inputs';
+import {createProject} from '../typescript/create-project';
+
+describe('getComponentInputs', () => {
+	let fixture: Fixture;
+
+	beforeEach(() => {
+		fixture = createFixture();
+	});
+
+	describe('Given component has no parent class', () => {
+		it('retrieves component inputs', () => {
+			fixture.givenComponentHasNoParentClass();
+			fixture.whenFindingComponentInputs('Test');
+
+			const expectedTestView = [
+				{
+					propertyName: 'myTestProperty',
+					initializer: "'abcd'",
+				},
+				{
+					propertyName: 'myOtherTestProperty',
+					initializer: "'abcd'",
+				},
+			];
+			fixture.thenInputsShouldHaveFollowingNamesAndInitializers(expectedTestView);
+		});
+	});
+
+	describe('Given component has only one parent class', () => {
+		it('retrieves component & parent inputs', () => {
+			fixture.givenComponentHasOneParentClass();
+			fixture.whenFindingComponentInputs('Test2');
+
+			const expectedTestView = [
+				{
+					initializer: "['azerty', 123, false]",
+					propertyName: 'mySecondTestProperty',
+				},
+				{
+					propertyName: 'myThirdTestProperty',
+				},
+				{
+					initializer: "{ name: 'Thomas' }",
+					propertyName: 'myFourthTestProperty',
+				},
+				{
+					initializer: "'efgh'",
+					propertyName: 'myOtherTestProperty',
+				},
+				{
+					initializer: "'Lorem ipsum'",
+					propertyName: 'myFutureOverriddenTestProperty',
+				},
+				{
+					initializer: "'abcd'",
+					propertyName: 'myTestProperty',
+				},
+			];
+			fixture.thenInputsShouldHaveFollowingNamesAndInitializers(expectedTestView);
+		});
+	});
+
+	describe('Given component has only multiple parents classes', () => {
+		it('retrieves mid-level component & parent inputs', () => {
+			fixture.givenComponentHasMultipleParentsClasses();
+			fixture.whenFindingComponentInputs('Test2');
+
+			const expectedTestView = [
+				{
+					initializer: "['azerty', 123, false]",
+					propertyName: 'mySecondTestProperty',
+				},
+				{
+					propertyName: 'myThirdTestProperty',
+				},
+				{
+					initializer: "{ name: 'Thomas' }",
+					propertyName: 'myFourthTestProperty',
+				},
+				{
+					initializer: "'efgh'",
+					propertyName: 'myOtherTestProperty',
+				},
+				{
+					initializer: "'Lorem ipsum'",
+					propertyName: 'myFutureOverriddenTestProperty',
+				},
+				{
+					initializer: "'abcd'",
+					propertyName: 'myTestProperty',
+				},
+			];
+			fixture.thenInputsShouldHaveFollowingNamesAndInitializers(expectedTestView);
+		});
+
+		it('retrieves component & all parents inputs', () => {
+			fixture.givenComponentHasMultipleParentsClasses();
+			fixture.whenFindingComponentInputs('Test3');
+
+			const expectedTestView = [
+				{
+					initializer: "'override_with_initial_value'",
+					propertyName: 'myThirdTestProperty',
+				},
+				{
+					initializer: "'Overridden Lorem ipsum'",
+					propertyName: 'myFutureOverriddenTestProperty',
+				},
+				{
+					initializer: "['azerty', 123, false]",
+					propertyName: 'mySecondTestProperty',
+				},
+				{
+					initializer: "{ name: 'Thomas' }",
+					propertyName: 'myFourthTestProperty',
+				},
+				{
+					initializer: "'efgh'",
+					propertyName: 'myOtherTestProperty',
+				},
+				{
+					initializer: "'abcd'",
+					propertyName: 'myTestProperty',
+				},
+			];
+			fixture.thenInputsShouldHaveFollowingNamesAndInitializers(expectedTestView);
+		});
+	});
+});
+
+interface InputsTestView {
+	propertyName: string;
+	initializer?: undefined | string;
+}
+
+const createFixture = () => {
+	let sourceFile: SourceFile;
+	let componentInputs: PropertyDeclaration[];
+
+	return {
+		givenComponentHasNoParentClass() {
+			const project: Project = createProject({useInMemoryFileSystem: true});
+			sourceFile = project.createSourceFile(
+				'class.ts',
+				`
+				class Test {
+					static myStaticProperty = 'a_static_value'
+
+					@Input()
+					myTestProperty = 'abcd'
+
+					@Input()
+					myOtherTestProperty = 'abcd'
+
+					method(param = 'string'): string {
+						return param;
+					}
+				}
+			`,
+			);
+		},
+
+		givenComponentHasOneParentClass() {
+			const project: Project = createProject({useInMemoryFileSystem: true});
+			sourceFile = project.createSourceFile(
+				'class.ts',
+				`
+				class Test {
+					static myStaticProperty = 'a_static_value'
+
+					@Input()
+					myTestProperty = 'abcd'
+
+					@Input()
+					myOtherTestProperty = 'abcd'
+
+					method(param = 'string'): string {
+						return param;
+					}
+				}
+
+				/**
+				 * Test2
+				*/
+				class Test2 extends Test {
+					@Input() mySecondTestProperty = ['azerty', 123, false]
+
+					@Input()
+					myThirdTestProperty: string;
+
+					@Input()
+					myFourthTestProperty = { name: 'Thomas' }
+
+					notAnAngularInput = 'test'
+
+					@Input()
+					override myOtherTestProperty = 'efgh'
+
+					@Input()
+					myFutureOverriddenTestProperty = 'Lorem ipsum';
+				}
+			`,
+			);
+		},
+
+		givenComponentHasMultipleParentsClasses() {
+			const project: Project = createProject({useInMemoryFileSystem: true});
+			sourceFile = project.createSourceFile(
+				'class.ts',
+				`
+				class Test {
+					static myStaticProperty = 'a_static_value'
+
+					@Input()
+					myTestProperty = 'abcd'
+
+					@Input()
+					myOtherTestProperty = 'abcd'
+
+					method(param = 'string'): string {
+						return param;
+					}
+				}
+
+				/**
+				 * Test2
+				*/
+				class Test2 extends Test {
+					@Input() mySecondTestProperty = ['azerty', 123, false]
+
+					@Input()
+					myThirdTestProperty: string;
+
+					@Input()
+					myFourthTestProperty = { name: 'Thomas' }
+
+					notAnAngularInput = 'test'
+
+					@Input()
+					override myOtherTestProperty = 'efgh'
+
+					@Input()
+					myFutureOverriddenTestProperty = 'Lorem ipsum';
+				}
+
+				/**
+				 * Test3
+				*/
+				class Test3 extends Test2 {
+					@Input()
+					myThirdTestProperty = 'override_with_initial_value';
+
+					@Input()
+					override myFutureOverriddenTestProperty = 'Overridden Lorem ipsum';
+				}
+			`,
+			);
+		},
+
+		whenFindingComponentInputs(componentClassName: string) {
+			const childClass = sourceFile.getClass(componentClassName) as ClassDeclaration;
+			componentInputs = getComponentInputs(childClass);
+		},
+
+		thenInputsShouldHaveFollowingNamesAndInitializers(expectedTestView: InputsTestView[]) {
+			const realTestView: InputsTestView[] = componentInputs.map((p) => ({
+				propertyName: p.getName(),
+				initializer: p.getInitializer()?.getText(),
+			}));
+			expect(realTestView).toEqual(expectedTestView);
+		},
+	};
+};
+
+type Fixture = ReturnType<typeof createFixture>;

--- a/libs/builder/helpers/testing/get-component-inputs.spec.ts
+++ b/libs/builder/helpers/testing/get-component-inputs.spec.ts
@@ -19,10 +19,12 @@ describe('getComponentInputs', () => {
 				{
 					propertyName: 'myTestProperty',
 					initializer: "'abcd'",
+					type: 'String',
 				},
 				{
 					propertyName: 'myOtherTestProperty',
 					initializer: "'abcd'",
+					type: 'String',
 				},
 			];
 			fixture.thenInputsShouldHaveFollowingNamesAndInitializers(expectedTestView);
@@ -38,25 +40,31 @@ describe('getComponentInputs', () => {
 				{
 					initializer: "['azerty', 123, false]",
 					propertyName: 'mySecondTestProperty',
+					type: '(string | number | boolean)[]',
 				},
 				{
 					propertyName: 'myThirdTestProperty',
+					type: 'String',
 				},
 				{
 					initializer: "{ name: 'Thomas' }",
 					propertyName: 'myFourthTestProperty',
+					type: '{ name: string; }',
 				},
 				{
 					initializer: "'efgh'",
 					propertyName: 'myOtherTestProperty',
+					type: 'String',
 				},
 				{
 					initializer: "'Lorem ipsum'",
 					propertyName: 'myFutureOverriddenTestProperty',
+					type: 'String',
 				},
 				{
 					initializer: "'abcd'",
 					propertyName: 'myTestProperty',
+					type: 'String',
 				},
 			];
 			fixture.thenInputsShouldHaveFollowingNamesAndInitializers(expectedTestView);
@@ -72,25 +80,32 @@ describe('getComponentInputs', () => {
 				{
 					initializer: "['azerty', 123, false]",
 					propertyName: 'mySecondTestProperty',
+					type: '(string | number | boolean)[]',
 				},
 				{
 					propertyName: 'myThirdTestProperty',
+					initializer: undefined,
+					type: 'String',
 				},
 				{
 					initializer: "{ name: 'Thomas' }",
 					propertyName: 'myFourthTestProperty',
+					type: '{ name: string; }',
 				},
 				{
-					initializer: "'efgh'",
+					initializer: 'false',
 					propertyName: 'myOtherTestProperty',
+					type: 'Boolean',
 				},
 				{
 					initializer: "'Lorem ipsum'",
 					propertyName: 'myFutureOverriddenTestProperty',
+					type: 'String',
 				},
 				{
 					initializer: "'abcd'",
 					propertyName: 'myTestProperty',
+					type: 'String',
 				},
 			];
 			fixture.thenInputsShouldHaveFollowingNamesAndInitializers(expectedTestView);
@@ -104,26 +119,32 @@ describe('getComponentInputs', () => {
 				{
 					initializer: "'override_with_initial_value'",
 					propertyName: 'myThirdTestProperty',
+					type: 'String',
 				},
 				{
 					initializer: "'Overridden Lorem ipsum'",
 					propertyName: 'myFutureOverriddenTestProperty',
+					type: 'String',
 				},
 				{
 					initializer: "['azerty', 123, false]",
 					propertyName: 'mySecondTestProperty',
+					type: '(string | number | boolean)[]',
 				},
 				{
 					initializer: "{ name: 'Thomas' }",
 					propertyName: 'myFourthTestProperty',
+					type: '{ name: string; }',
 				},
 				{
-					initializer: "'efgh'",
+					initializer: 'false',
 					propertyName: 'myOtherTestProperty',
+					type: 'Boolean',
 				},
 				{
 					initializer: "'abcd'",
 					propertyName: 'myTestProperty',
+					type: 'String',
 				},
 			];
 			fixture.thenInputsShouldHaveFollowingNamesAndInitializers(expectedTestView);
@@ -133,6 +154,7 @@ describe('getComponentInputs', () => {
 
 interface InputsTestView {
 	propertyName: string;
+	type: string;
 	initializer?: undefined | string;
 }
 
@@ -240,7 +262,7 @@ const createFixture = () => {
 					notAnAngularInput = 'test'
 
 					@Input()
-					override myOtherTestProperty = 'efgh'
+					override myOtherTestProperty: boolean = false
 
 					@Input()
 					myFutureOverriddenTestProperty = 'Lorem ipsum';
@@ -269,6 +291,7 @@ const createFixture = () => {
 			const realTestView: InputsTestView[] = componentInputs.map((p) => ({
 				propertyName: p.getName(),
 				initializer: p.getInitializer()?.getText(),
+				type: p.getType().getApparentType().getText(),
 			}));
 			expect(realTestView).toEqual(expectedTestView);
 		},


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## Issue Number
<!-- Bugs and features must be linked to an issue. -->

Issue Number: N/A


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No



## Other information

This PR allows extending from base component and display base component inputs on playground controls section.

Example:

```ts
// Omitting stuff for simplicity

@Directive()
export class BaseComponent {
    @Input() size: 'small' | 'medium' | 'large' = 'medium'
}

@Component({
    selector: 'my-component'
})
export class MyComponent extends BaseComponent {
    @Input() title: string;
    @Input() content: string;
}
```

Before this PR, only `title` and `content` will be displayed on playground controls section.

The playground will now correctly display the 3 following `@Input` controls: `size`, `title` and `content`.


