### PR TITLE
feat(builder): add `excludeByTsDocsTags` function to filter out nodes…

### DIFF
--- a/libs/builder/engine/nunjucks/filters.ts
+++ b/libs/builder/engine/nunjucks/filters.ts
@@ -6,6 +6,7 @@ export {
 	declarationImport,
 	displayReturnType,
 	displayType,
+	excludeByTsDocsTags,
 	extractDocs,
 	extractParameterDocs,
 	extractSeeDocs,

--- a/libs/builder/helpers/typescript/exclude-by-ts-docs-tags.ts
+++ b/libs/builder/helpers/typescript/exclude-by-ts-docs-tags.ts
@@ -1,0 +1,18 @@
+import { asArray } from '@ng-doc/core';
+import { JSDocableNode } from 'ts-morph';
+
+/**
+ *
+ * @param nodes
+ * @param tags
+ */
+export function excludeByTsDocsTags<T extends JSDocableNode>(
+	nodes: T[],
+	tags: string | string[],
+): T[] {
+	return nodes.filter((node: T) => {
+		return !node
+			.getJsDocs()
+			.some((jsDoc) => jsDoc.getTags().some((tag) => asArray(tags).includes(tag.getTagName())));
+	});
+}

--- a/libs/builder/helpers/typescript/index.ts
+++ b/libs/builder/helpers/typescript/index.ts
@@ -3,6 +3,7 @@ export * from './class';
 export * from './create-project';
 export * from './declaration-import';
 export * from './display-type';
+export * from './exclude-by-ts-docs-tags';
 export * from './filter-by-scope';
 export * from './filter-by-static';
 export * from './first-node-with-comment';

--- a/libs/builder/templates/api/class.html.nunj
+++ b/libs/builder/templates/api/class.html.nunj
@@ -32,10 +32,10 @@
 {% endblock %}
 
 {% block overview %}
-    {%- set constructors = declaration.getConstructors() | filterByScope("public") -%}
-    {%- set allProperties = declaration | getClassProperties | filterByScope(["public", "protected"]) | filterUselessMembers | sortByNodesName -%}
-    {%- set allMethods = declaration | getClassMethods | filterByScope(["public", "protected"]) | filterUselessMembers | sortByNodesName -%}
-    {%- set allAccessors = declaration | getClassAccessors | filterByScope(["public", "protected"]) | filterUselessMembers | sortByNodesName -%}
+    {%- set constructors = declaration.getConstructors() | filterByScope("public") | excludeByTsDocsTags('internal') -%}
+    {%- set allProperties = declaration | getClassProperties | excludeByTsDocsTags('internal') | filterByScope(["public", "protected"]) | filterUselessMembers | sortByNodesName -%}
+    {%- set allMethods = declaration | getClassMethods | excludeByTsDocsTags('internal') | filterByScope(["public", "protected"]) | filterUselessMembers | sortByNodesName -%}
+    {%- set allAccessors = declaration | getClassAccessors | excludeByTsDocsTags('internal') | filterByScope(["public", "protected"]) | filterUselessMembers | sortByNodesName -%}
 
     {%- set staticProperties = allProperties | filterByStatic(true) -%}
     {%- set staticAccessors = allAccessors | filterByStatic(true) -%}


### PR DESCRIPTION
… based on TS documentation tags

PR introduces the `internal` TSDoc tag for all class members

```ts
class SomeClass {

  /**
   * @internal
   */
  _prop!: string;

  prop!: string;

}
```

The `_prop` property will be skipped in the generated API documentation

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number

<!-- Bugs and features must be linked to an issue. -->

Issue Number: N/A

## Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Other information
