### PR TITLE
[Docs] Update ng-doc path in docs and log outputs

### DIFF
--- a/apps/ng-doc/docs/getting-started/configuration/index.md
+++ b/apps/ng-doc/docs/getting-started/configuration/index.md
@@ -99,12 +99,12 @@ const config: NgDocConfiguration = {
 export default config;
 ```
 
-After that NgDoc will generated and store everything inside `src/.ng-doc/app-name` folder.
+After that NgDoc will generated and store everything inside `src/ng-doc/app-name` folder.
 But remember that you should not commit this folder to your repository, and also update
 the following things:
 
 - Update the path to the `@ng-doc/generated` directory in `tsconfig.json` paths section.
-- Update the path to the `.ng-doc/app-name/assets` folder in `angular.json`np
+- Update the path to the `ng-doc/app-name/assets` folder in `angular.json`np
 
 ## Configuring repository
 

--- a/apps/ng-doc/docs/getting-started/installation/index.md
+++ b/apps/ng-doc/docs/getting-started/installation/index.md
@@ -105,14 +105,14 @@ by adding them to your `styles` array.
 }
 ```
 
-### Adding .ng-doc folder to gitignore
+### Adding ng-doc folder to gitignore
 
-`.ng-doc` folder contains generated NgDoc files, you need to add it to your `.gitignore`,
+`ng-doc` folder contains generated NgDoc files, you need to add it to your `.gitignore`,
 because NgDoc regenerates them every time the application is launched.
 
 ```gitignore name=".gitignore"
 ## NgDoc folder
-.ng-doc
+/ng-doc
 ```
 
 ### Adding assets
@@ -140,7 +140,7 @@ useful things. You also need to add them to your application's assets.
               },
               {
                 "glob": "**/*",
-                "input": ".ng-doc/<project-name>/assets",
+                "input": "ng-doc/<project-name>/assets",
                 "output": "assets/ng-doc"
               }
             ]
@@ -170,7 +170,7 @@ useful things. You also need to add them to your application's assets.
           },
           {
             "glob": "**/*",
-            "input": ".ng-doc/<project-name>/assets",
+            "input": "ng-doc/<project-name>/assets",
             "output": "assets/ng-doc"
           }
         ]
@@ -194,8 +194,8 @@ the generated files and `allowSyntheticDefaultImports` option.
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "paths": {
-      "@ng-doc/generated": [".ng-doc/<project-name>/index.ts"],
-      "@ng-doc/generated/*": [".ng-doc/<project-name>/*"]
+      "@ng-doc/generated": ["ng-doc/<project-name>/index.ts"],
+      "@ng-doc/generated/*": ["ng-doc/<project-name>/*"]
     }
   }
 }

--- a/libs/add/schematics/ng-add/steps/add-git-ignore.ts
+++ b/libs/add/schematics/ng-add/steps/add-git-ignore.ts
@@ -12,14 +12,14 @@ export function addGitIgnore(): Rule {
 			const logger = context.logger.createChild('add-gitignore');
 
 			context.logger.info(`[INFO]: Git ignore`);
-			logger.info(`🔄 Adding ".ng-doc" folder to .gitignore file...`);
+			logger.info(`🔄 Adding "ng-doc" folder to .gitignore file...`);
 
 			try {
 				const gitignore: Buffer | null = tree.read('.gitignore');
 
 				if (!gitignore) {
 					logger.warn(
-						`⚠️ ".gitignore" file was not found, please add ".ng-doc" folder into it manually.`,
+						`⚠️ ".gitignore" file was not found, please add "/ng-doc" folder into it manually.`,
 					);
 
 					return;

--- a/libs/add/schematics/ng-add/steps/add-tsconfig-paths.ts
+++ b/libs/add/schematics/ng-add/steps/add-tsconfig-paths.ts
@@ -22,7 +22,7 @@ export function addTsconfigPaths(options: Schema): Rule {
 			const logger = context.logger.createChild('add-tsconfig-paths');
 
 			context.logger.info(`[INFO]: TSConfig paths`);
-			logger.info(`🔄 Configuring TSConfig paths to allow import from ".ng-doc" folder...`);
+			logger.info(`🔄 Configuring TSConfig paths to allow import from "ng-doc" folder...`);
 
 			try {
 				const project: ProjectDefinition | undefined = getProject(options, workspace);

--- a/libs/builder/interfaces/configuration.ts
+++ b/libs/builder/interfaces/configuration.ts
@@ -21,7 +21,7 @@ export interface NgDocConfiguration {
 	 *
 	 * Remember that if you change this path, you also need to change the following:
 	 * - Change the path to the `@ng-doc/generated` directory in `tsconfig.json`
-	 * - Change the path to the `.ng-doc/app-name/assets` folder in `angular.json`
+	 * - Change the path to the `ng-doc/app-name/assets` folder in `angular.json`
 	 */
 	outDir?: string;
 	/**


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI-related changes
- [x] Documentation content changes
- [x] Other... Please describe:

Docs and log ouput were still using the old '.ng-doc' directory name instead of 'ng-doc':
- Docs
  - Installation
  - Configuration
- Log output
  - `add` schematic steps
    - `add-gitignore`
    - `add-tsconfig-paths`

## Issue Number

<!-- Bugs and features must be linked to an issue. -->

Issue Number: #150 

## Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Other information
