### PR TITLE
fix(app): treat links with `mailto:` prefix as external

### DIFF
--- a/libs/app/components/page-link/page-link.component.ts
+++ b/libs/app/components/page-link/page-link.component.ts
@@ -45,7 +45,7 @@ export class NgDocPageLinkComponent implements OnInit, OnChanges {
   }
 
   get isExternalLink(): boolean {
-    return this.href.startsWith('http');
+    return this.href.startsWith('http') || this.href.startsWith('mailto:');
   }
 
   get path(): string {


### PR DESCRIPTION
Resolves #194

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number

<!-- Bugs and features must be linked to an issue. -->

Issue Number: #194 

## Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Other information

Now `mailto:` works (also putting just e-mail address in markdown creates an anchor with mailto prefix), but this simple fix also makes the 'external website' icon appear. Possibly, we could treat mail anchor differently and don't show icon.

I tried to add jest tests, but I'm not very familiar with jest configuration and I didn't manage to configure project properly to work, I could add tests with a little guidance on how to configure libs/app project to run tests (currently fails on importing esmodules), I've tried "ECMAScript modules" section from jest docs but couldn't make it work.