### PR TITLE
Fix #269 - status tag visible in description

### DIFF
--- a/libs/builder/helpers/get-js-doc.ts
+++ b/libs/builder/helpers/get-js-doc.ts
@@ -129,7 +129,7 @@ export function getJsDocParam(node: JSDocableNode, paramName: string): string {
   const parserContext = tsdocParser.parseString(jsDocs[0]?.getText() ?? '');
 
   const param = Formatter.renderDocNodes(
-    parserContext.docComment.params.tryGetBlockByName(paramName)?.getChildNodes() ?? [],
+    parserContext.docComment.params.tryGetBlockByName(paramName)?.content?.getChildNodes() ?? [],
   );
 
   return markdownToHtml(param).trim();

--- a/libs/builder/helpers/get-js-doc.ts
+++ b/libs/builder/helpers/get-js-doc.ts
@@ -1,5 +1,10 @@
-import { TSDocParser } from '@microsoft/tsdoc';
-import { type DocNode, DocExcerpt } from '@microsoft/tsdoc';
+import {
+  type DocNode,
+  DocErrorText,
+  DocExcerpt,
+  DocPlainText,
+  TSDocParser,
+} from '@microsoft/tsdoc';
 import { asArray, isPresent } from '@ng-doc/core';
 import { JSDocableNode } from 'ts-morph';
 
@@ -12,7 +17,7 @@ export class Formatter {
       if (docNode instanceof DocExcerpt) {
         result += docNode.content.toString();
       }
-      for (const childNode of docNode.getChildNodes()) {
+      for (const childNode of Formatter.filterOutStatusTag(docNode.getChildNodes())) {
         result += Formatter.renderDocNode(childNode);
       }
     }
@@ -24,6 +29,31 @@ export class Formatter {
     for (const docNode of docNodes) {
       result += Formatter.renderDocNode(docNode);
     }
+    return result;
+  }
+
+  private static filterOutStatusTag(docNodes: readonly DocNode[]): readonly DocNode[] {
+    if (docNodes.length < 2) return docNodes;
+
+    const result: DocNode[] = [];
+
+    for (let i = 0; i < docNodes.length; i += 2) {
+      const node1 = docNodes.at(i),
+        node2 = docNodes.at(i + 1);
+
+      if (
+        node1 instanceof DocErrorText &&
+        node1.text === '@' &&
+        node2 instanceof DocPlainText &&
+        node2.text.startsWith('status:')
+      ) {
+        continue;
+      }
+
+      if (node1) result.push(node1);
+      if (node2) result.push(node2);
+    }
+
     return result;
   }
 }

--- a/libs/builder/helpers/testing/get-js-doc.spec.ts
+++ b/libs/builder/helpers/testing/get-js-doc.spec.ts
@@ -36,6 +36,39 @@ describe('presentation', () => {
 
       expect(getJsDocDescription(declaration)).toBe('<p>Test class</p>');
     });
+
+    it('should not return status tag in description', () => {
+      const sourceFile: SourceFile = project.createSourceFile(
+        'code.ts',
+        `
+        /**
+        * Test class
+        *
+        * @status:warning Test status
+        */
+        export class Test {}
+      `,
+      );
+      const declaration = sourceFile.getClassOrThrow('Test');
+
+      expect(getJsDocDescription(declaration)).toBe('<p>Test class</p>');
+    });
+
+    it('should not return status tag in description, even if part of paragraph', () => {
+      const sourceFile: SourceFile = project.createSourceFile(
+        'code.ts',
+        `
+        /**
+        * Test class
+        * @status:warning Test status
+        */
+        export class Test {}
+      `,
+      );
+      const declaration = sourceFile.getClassOrThrow('Test');
+
+      expect(getJsDocDescription(declaration)).toBe('<p>Test class</p>');
+    });
   });
 
   describe('getJsDocTag', () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number

<!-- Bugs and features must be linked to an issue. -->

Issue Number: #269 

## Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Other information

I wanted to add `@status:` as a custom TSDoc tag, but TSDoc tags can only contain letters and numbers, so `:` doesn't allow it.

As well as fixing the bug, I noticed that `getJsDocParam` didn't pass the tests, so I fixed that too.
